### PR TITLE
🐛 helmet contentSecurityPolicy directive 수정

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -14,8 +14,18 @@ import apiRouter from './routes/api.js';
 
 const app = express();
 
+const defaultDirectives = helmet.contentSecurityPolicy.getDefaultDirectives();
+const upgradeInsecureRequests = 'upgrade-insecure-requests';
+const { [upgradeInsecureRequests]: removeDirective, ...otherDefaultDirectives } = defaultDirectives;
+
 app.use(
   helmet({
+    contentSecurityPolicy: {
+      useDefaults: false,
+      directives: {
+        ...otherDefaultDirectives,
+      },
+    },
     crossOriginEmbedderPolicy: false,
   }),
 );


### PR DESCRIPTION
## Description
- safari에서 http -> https 리다이렉션을 하므로 `upgrade-insecure-requests` directive 삭제

## Related Issues

resolve #13

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Issue TODO finished
- [X] No Conflicts with the base branch
